### PR TITLE
Add manual page with swipeable cards and attribute overlays

### DIFF
--- a/eunoia_web/src/App.js
+++ b/eunoia_web/src/App.js
@@ -9,6 +9,7 @@ import RegisterCharityPage from './pages/RegisterCharityPage';
 import AboutPage from './pages/AboutPage';
 import ManagementPage from './pages/ManagementPage';
 import TransparencyPage from './pages/TransparencyPage';
+import ManualPage from './pages/ManualPage';
 import { AppProvider } from './components/AppProvider';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
@@ -96,15 +97,16 @@ function App() {
               <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
                 <Navbar />
                 <main style={{ flex: 1 }}>
-                  <Routes>
-                    <Route path="/" element={<HomePage />} />
-                    <Route path="/donate" element={<DonatePage />} />
-                    <Route path="/charities" element={<CharitiesPage />} />
-                    <Route path="/register-charity" element={<RegisterCharityPage />} />
-                    <Route path="/about" element={<AboutPage />} />
-                    <Route path="/management" element={<ManagementPage />} />
-                    <Route path="/transparency" element={<TransparencyPage />} />
-                  </Routes>
+                    <Routes>
+                      <Route path="/" element={<HomePage />} />
+                      <Route path="/donate" element={<DonatePage />} />
+                      <Route path="/charities" element={<CharitiesPage />} />
+                      <Route path="/register-charity" element={<RegisterCharityPage />} />
+                      <Route path="/about" element={<AboutPage />} />
+                      <Route path="/management" element={<ManagementPage />} />
+                      <Route path="/transparency" element={<TransparencyPage />} />
+                      <Route path="/manual" element={<ManualPage />} />
+                    </Routes>
                 </main>
                 <Footer />
               </div>

--- a/eunoia_web/src/components/AttributeRings.js
+++ b/eunoia_web/src/components/AttributeRings.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { styled, alpha } from '@mui/material/styles';
+
+const Ring = styled(Box)(({ theme }) => ({
+  width: 16,
+  height: 16,
+  borderRadius: '50%',
+  border: `2px solid ${theme.palette.secondary.main}`,
+  backgroundColor: alpha(theme.palette.secondary.main, 0.2),
+}));
+
+const AttributeRings = ({ attributes = [] }) => (
+  <Box display="flex" gap={1}>
+    {attributes.map((attr, idx) => (
+      <Ring key={idx} title={attr} />
+    ))}
+  </Box>
+);
+
+export default AttributeRings;

--- a/eunoia_web/src/components/SwipeableImageCards.js
+++ b/eunoia_web/src/components/SwipeableImageCards.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Box, IconButton as MuiIconButton, Typography, Paper } from '@mui/material';
-import { styled, keyframes, alpha } from '@mui/material/styles';
+import { styled, alpha } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
-import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder'; // Or FavoriteIcon for a filled heart
+import CheckIcon from '@mui/icons-material/Check';
+import AttributeRings from './AttributeRings';
 
 // --- Styled Components --- //
 
@@ -60,12 +61,16 @@ const CardUI = styled(Paper)(({ theme, imageUrl, zIndexOffset = 0 }) => ({
 //   borderBottomRightRadius: '20px',
 // });
 
-const ActionButtonsContainer = styled(Box)({
+const OverlayButtonsUI = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  bottom: theme.spacing(2),
+  left: 0,
+  width: '100%',
   display: 'flex',
-  justifyContent: 'center',
-  gap: '20px',
-  marginTop: '20px',
-});
+  justifyContent: 'space-between',
+  padding: `0 ${theme.spacing(2)}`,
+  pointerEvents: 'none',
+}));
 
 const ActionButtonUI = styled(MuiIconButton)(({ theme, colorvariant }) => ({
   width: '60px',
@@ -77,7 +82,18 @@ const ActionButtonUI = styled(MuiIconButton)(({ theme, colorvariant }) => ({
     transform: 'scale(1.1)',
     backgroundColor: 'white',
   },
+  pointerEvents: 'auto',
   // MUI Icons have their own sizing, adjust if needed via fontSize prop on the icon itself
+}));
+
+const AttributeRingsContainer = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  top: theme.spacing(2),
+  left: 0,
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  pointerEvents: 'none',
 }));
 
 const EmptyStateUI = styled(Box)(({ theme }) => ({
@@ -164,7 +180,7 @@ const SwipeableImageCards = ({ imagesData, onSwipe }) => {
   if (showEmptyState) {
     return (
       <EmptyStateUI>
-        <FavoriteBorderIcon className="empty-state-icon" /> {/* Or CheckCircleOutlineIcon */}
+        <CheckIcon className="empty-state-icon" />
         <Typography variant="h6" component="h3" fontWeight="semibold" gutterBottom>
           All Set!
         </Typography>
@@ -183,32 +199,38 @@ const SwipeableImageCards = ({ imagesData, onSwipe }) => {
       <CardContainerUI>
         {currentCardsData.map((cardData, index) => (
           <CardUI
-            key={cardData.id} // Key should be stable and unique
-            ref={cardElementsRef.current[cardData.id]} // Assign ref using card ID
-            imageUrl={cardData.imgSrc} 
-            zIndexOffset={index} // For stacking effect (topmost card has index 0)
-            // Drag handlers will be added in a future step
-          >
-            {/* CardContentUI removed to not show text on images */}
-          </CardUI>
+            key={cardData.id}
+            ref={cardElementsRef.current[cardData.id]}
+            imageUrl={cardData.imgSrc}
+            zIndexOffset={index}
+          />
         ))}
+        {topCard && (
+          <>
+            {topCard.attributes && (
+              <AttributeRingsContainer>
+                <AttributeRings attributes={topCard.attributes} />
+              </AttributeRingsContainer>
+            )}
+            <OverlayButtonsUI>
+              <ActionButtonUI
+                colorvariant="dislike"
+                onClick={() => topCard && handleSwipe('left', topCard.id)}
+                disabled={isAnimating || !topCard}
+              >
+                <CloseIcon fontSize="large" />
+              </ActionButtonUI>
+              <ActionButtonUI
+                colorvariant="like"
+                onClick={() => topCard && handleSwipe('right', topCard.id)}
+                disabled={isAnimating || !topCard}
+              >
+                <CheckIcon fontSize="large" />
+              </ActionButtonUI>
+            </OverlayButtonsUI>
+          </>
+        )}
       </CardContainerUI>
-      <ActionButtonsContainer>
-        <ActionButtonUI 
-          colorvariant="dislike" 
-          onClick={() => topCard && handleSwipe('left', topCard.id)}
-          disabled={isAnimating || !topCard}
-        >
-          <CloseIcon fontSize="large" />
-        </ActionButtonUI>
-        <ActionButtonUI 
-          colorvariant="like" 
-          onClick={() => topCard && handleSwipe('right', topCard.id)}
-          disabled={isAnimating || !topCard}
-        >
-          <FavoriteBorderIcon fontSize="large" />
-        </ActionButtonUI>
-      </ActionButtonsContainer>
     </Box>
   );
 };

--- a/eunoia_web/src/pages/ManualPage.js
+++ b/eunoia_web/src/pages/ManualPage.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Container, Typography } from '@mui/material';
+import SwipeableImageCards from '../components/SwipeableImageCards';
+import data from '../assets/data.json';
+
+const ManualPage = () => {
+  const imagesData = data.map((item, idx) => ({
+    id: idx,
+    imgSrc: item.logo,
+    attributes: item.tags || [],
+  }));
+
+  const handleSwipe = () => {};
+
+  return (
+    <Container sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Manual
+      </Typography>
+      <SwipeableImageCards imagesData={imagesData} onSwipe={handleSwipe} />
+    </Container>
+  );
+};
+
+export default ManualPage;


### PR DESCRIPTION
## Summary
- overlay accept/decline buttons directly on swipeable cards
- display attribute rings above top card and expose simple ring component
- wire new manual page into routing

## Testing
- `npm test --prefix eunoia_web -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68c0651280c483278a187127f9e6ddfc